### PR TITLE
TASK: apply version updates to master

### DIFF
--- a/.github/workflows/papermc-build-check.yml
+++ b/.github/workflows/papermc-build-check.yml
@@ -92,7 +92,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Building Waterfall Image
-        run: cd waterfall && docker build -t zombymediaic/papermc:waterfall . && cd ..
+        run: cd waterfall-1.18 && docker build -t zombymediaic/papermc:waterfall-1.18 . && cd ..
 
       - name: Moving Card to Building
         uses: alex-page/github-project-automation-plus@v0.3.0

--- a/1.17.1/run.sh
+++ b/1.17.1/run.sh
@@ -29,7 +29,7 @@ if test -f "$JARFILE"; then
 	screen -S Minecraft-Server /bin/sh -c "java -Xmx${RAM} -Xms${RAM} -jar papermc.jar"
 else
 	echo "Creating new Files"
-	wget https://papermc.io/api/v2/projects/paper/versions/1.17.1/builds/408/downloads/paper-1.17.1-408.jar -O /temp/papermc.jar
+	wget https://papermc.io/api/v2/projects/paper/versions/1.17.1/builds/409/downloads/paper-1.17.1-409.jar -O /temp/papermc.jar
 	touch /temp/eula.txt
 	echo "eula=true" > /temp/eula.txt
 	sed -i -e 's/false/true/g' /temp/eula.txt

--- a/1.18.1/run.sh
+++ b/1.18.1/run.sh
@@ -31,7 +31,7 @@ if test -f "$JARFILE"; then
 	screen -S Minecraft-Server /bin/sh -c "java -Xmx${RAM} -Xms${RAM} -jar papermc.jar"
 else
 	echo "Creating new Files"
-	wget https://papermc.io/api/v2/projects/paper/versions/1.18.1/builds/152/downloads/paper-1.18.1-152.jar -O /temp/papermc.jar
+	wget https://papermc.io/api/v2/projects/paper/versions/1.18.1/builds/207/downloads/paper-1.18.1-207.jar -O /temp/papermc.jar
 	touch /temp/eula.txt
 	echo "eula=true" > /temp/eula.txt
 	sed -i -e 's/false/true/g' /temp/eula.txt


### PR DESCRIPTION
TASK: updated 1.17.1 to version to 409
- Fix entity equipment on cancellation of EntityDeathEvent
- Fix entity armor not showing on death animation
- [1.17.1] Backport #5740 and #7355 to 1.17.1

TASK: updated 1.18.1 to version to 207
- Fix xp reward for baby zombies (#7353)
- Fix NPE for bucket empty result stack being null (#7354)
- Fix and deprecate ItemStack#getI18NDisplayName (#7358)
- Expand Panda API (#7061)
- Add unsupported field to disable username validation (#7350)
- Fix Lure infinite loop (#6850)
- Change default for hoppers ignoring occluded blocks (#7342)
- Push illegal char kick to main thread (#7363)
- [ci skip] Fix incorrect javadoc for Mob pathfinding API (#6842)
- Warn on strange https://github.com/eventhandler return types (#7372)
- Fix setting unplaced furnace cook speed multiplier (#7327)
- Fix setSpawnedItem from 1.18 update (#7328)
- Offset spigot item optimizations instead of Mojang's (#6290)
- Deprecate log4j logger method in `Plugin`
- Add Multi Block Change API (#7333)
- Update ASM EventExecutor generator patch to respect event handler return types. Fixes #7311 (#7317)
- Make tag presets unmodifiable (#7378)
- Fix NotePlayEvent (#5180)
- Updated Upstream (Bukkit/CraftBukkit/Spigot) (#7359)
- [ci skip] Fix multiple ItemStack array nullability mistakes (#7055)
- Lock Frozen Ticks API (#7207)
- Dolphin API (#7102)
- Add configurable stronghold seed (#7334)
- More PotionEffectType API (#5737)
- Add STRUCTURE_TYPE registry entry (#6400)
- Update tiny-remapper
- [ci skip] Update parameter mappings
- [ci skip] Fix param mismatch from last commit
- Updated Upstream (Bukkit/CraftBukkit) (#7411)
- [ci skip] Update paperweight to 1.3.4
- Updated Upstream (Bukkit/CraftBukkit) (#7428)
- Use a CHM for StructureTemplate.Pallete cache
- Updated Upstream (Bukkit/CraftBukkit)
- Rebuild patches
- Use correct headerLocation for regionfile initialisation
- Fix infinite recursion in spawnCategoryForChunk/Position
- API for creating command sender which forwards feedback (#7432)
- fix portal linking in upgraded chunks (fixes #7419) (#7438)
- Use destination world when preloading spawn chunk (#7441)
- Implement World#regenerateChunk (#7425)
- Log exceptions thrown during chat processing (#7467)
- Updated Upstream (Bukkit/CraftBukkit/Spigot) (#7454)
- Optimize Util#sequence (#7115)
- Make Panda implement Sittable (#7414)
- Fix issues with LimitedRegion (#7343)
- Fix cancelled snow bucket placement (#6751)
- Don't load plugins prefixed with a dot (#7392)
- Fix PlayerProfile BukkitObject serialization, deprecate setName and setId for removal (#7471)
- Fix IllegalArgumentException for /paper mobcaps command (#7472)
- properly fix IllegalArgumentException in `/paper mobcaps` command - fix IllegalArgumentException in `/paper playermobcaps` command - add missing Validate calls to CraftServer#getSpawnLimit(SpawnCategory)
- Updated Upstream (Bukkit/CraftBukkit/Spigot) (#7480)
- Mark ChatRender#render as ApiStatus.Override
- Add GameEvent tags (#6439)
- Use access transformers for player profile API (#7468)
- 1.18 misc performance dev branch (#7368)
- Fix entity armor not showing on death animation (#7355)
- Updated Upstream (Bukkit/CraftBukkit)
- Furnace RecipesUsed API (#7399)
- Configurable sculk sensor listener range (#6443)