### PR TITLE
TASK: updated to the latest 1.18.2 papermc release

### DIFF
--- a/1.18.2/run.sh
+++ b/1.18.2/run.sh
@@ -31,7 +31,7 @@ if test -f "$JARFILE"; then
 	screen -S Minecraft-Server /bin/sh -c "java -Xmx${RAM} -Xms${RAM} -jar papermc.jar"
 else
 	echo "Creating new Files"
-	wget https://papermc.io/api/v2/projects/paper/versions/1.18.2/builds/250/downloads/paper-1.18.2-250.jar -O /temp/papermc.jar
+	wget https://papermc.io/api/v2/projects/paper/versions/1.18.2/builds/277/downloads/paper-1.18.2-277.jar -O /temp/papermc.jar
 	touch /temp/eula.txt
 	echo "eula=true" > /temp/eula.txt
 	sed -i -e 's/false/true/g' /temp/eula.txt

--- a/waterfall-1.18/run.sh
+++ b/waterfall-1.18/run.sh
@@ -9,7 +9,7 @@ JARFILE=/server/waterfall.jar
 if test -f "$JARFILE"; then
         screen -S Minecraft-Server /bin/sh -c "java -Xmx1024M -Xms1024M -jar waterfall.jar"
 else
-        wget https://papermc.io/api/v2/projects/waterfall/versions/1.18/builds/475/downloads/waterfall-1.18-475.jar -O waterfall.jar
+        wget https://papermc.io/api/v2/projects/waterfall/versions/1.18/builds/483/downloads/waterfall-1.18-483.jar -O waterfall.jar
         touch eula.txt
         echo "eula=true" > eula.txt
         sed -i -e 's/false/true/g' eula.txt


### PR DESCRIPTION
Changes:
#251 - [0ca80c7] Add getComputedBiome API (#5668)
#252 - [2d3e8f7] Properly lookup random-ticked precipitation blocks (#7606)
#253 - [f35a0ce] Remove Java version check once and for all (#7612)
#254 - [1c5f8b0] Updated Upstream (Bukkit/CraftBukkit) (#7604)
#255 - [f0d0078] Add debug for invalid GameProfiles on skull blocks/items (#7512)
#256 - [8788bf7] fix datapacks not being able to modify nether/end (#7588)
#257 - [b8c90d2] Added method to check snapshot state of TileStates (#7325)
#258 - [8897cea] Add enchantWithLevels API (#7615)
#259 - [2eeca6f] Fix world saving in unloadWorld
#260 ++
           | [319d5fa] Fix state locking for getTopMRUProfiles & getProfileIfCached
           | [bc68ee0] Remove redundant GameProfileCache diff
#261 - [855637f] Updated Upstream (CraftBukkit) (#7624)
#262 - [5eb61dd] Buffer OOB setBlock calls
#263 - [7b46444] Properly create profiles with custom name/uuid (#7558)
#264 - [a686ff5] Add more missing entity API (#7592)
#265 - [993f828] Add TameableDeathMessageEvent (#5392)
#266 ++
           | [a939d6e] Fix generator settings string for flat-type worlds (#7568)
           | [ab666a4] Deprecating remaining blockkey methods (#7638)
#267 - [e7d928a] Fix EntityChangeBlockEvent#getBlockData for when sheep eats grass block (#7646)
#268 - [e2f743d] Fix PalettedContainer synchronization (#7663)
#269 - [7fa8870] Updated Upstream (Bukkit/CraftBukkit) (#7672)
#270 - [fa68bb1] Fix entity position desync for hanging entities (#7659)
#271 - [d3c1023] fix player loottables running when mob loot gamerule is false (#7651)
#272 - [7f47b9b] Remove KeyedObject interface (#7680)
#273 - [7bf9446] Add per player chunk loading limits
#274 - [04c7b16] Undeprecate Material#isLegacy (#7679)
#275 - [443c506] Fix Nullability Annotations for PrepareItemEnchantEvent (#7681)
#276 - [ea2c81e] Fix lectern quick move
#277 - [87e11bf] Cache resource keys instead of trying to create them (#7643)